### PR TITLE
fix(generate): honor --target when choosing PR base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dist/
 
 # local build artifacts
 /prescribe
+.gocache/

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ prescribe create --use-last --draft
 
 # B) One command: generate + create (dry-run first)
 prescribe generate --create --create-dry-run
-prescribe generate --create --create-draft --create-base main
+prescribe generate --create --create-draft
 ```
 
 Notes:
@@ -240,7 +240,7 @@ prescribe generate --preset concise
 prescribe generate --create --create-dry-run
 
 # Generate and create PR (draft)
-prescribe generate --create --create-draft --create-base main
+prescribe generate --create --create-draft
 ```
 
 ### PR Creation

--- a/cmd/prescribe/cmds/generate_test.go
+++ b/cmd/prescribe/cmds/generate_test.go
@@ -1,0 +1,50 @@
+package cmds
+
+import "testing"
+
+func TestResolveCreateBase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		explicitBase  string
+		sessionTarget string
+		want          string
+	}{
+		{
+			name:          "explicit base wins",
+			explicitBase:  "main",
+			sessionTarget: "develop",
+			want:          "main",
+		},
+		{
+			name:          "fallback to session target when empty",
+			explicitBase:  "",
+			sessionTarget: "develop",
+			want:          "develop",
+		},
+		{
+			name:          "trim whitespace",
+			explicitBase:  "  ",
+			sessionTarget: " master ",
+			want:          "master",
+		},
+		{
+			name:          "explicit base trims whitespace",
+			explicitBase:  "  release ",
+			sessionTarget: "develop",
+			want:          "release",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveCreateBase(tt.explicitBase, tt.sessionTarget)
+			if got != tt.want {
+				t.Fatalf("resolveCreateBase(%q, %q) = %q, want %q", tt.explicitBase, tt.sessionTarget, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/doc/topics/02-how-to-generate-pr-description.md
+++ b/pkg/doc/topics/02-how-to-generate-pr-description.md
@@ -262,8 +262,8 @@ prescribe create --use-last --draft
 # Safe preview
 prescribe generate --create --create-dry-run
 
-# Create a draft PR (base defaults to main; override if needed)
-prescribe generate --create --create-draft --create-base main
+# Create a draft PR (base defaults to the session/--target branch; override if needed)
+prescribe generate --create --create-draft
 ```
 
 ### Notes / gotchas
@@ -314,5 +314,4 @@ These locations are the durable “project configuration surface” of `prescrib
 - **Prompt presets**:
   - `<repo>/.pr-builder/prompts/*.yaml`
   - `~/.pr-builder/prompts/*.yaml`
-
 


### PR DESCRIPTION
Fixes a mismatch where `prescribe generate --target develop --create` would still create the PR against `main` (because `--create-base` defaulted to `main`), producing an incorrect/mismatched PR diff or failing on repos without `main`.

Changes:
- `generate --create` now defaults the PR base to the session/`--target` branch when `--create-base` is not explicitly set.
- Docs updated to reflect the new default.
- Added a small unit test for base resolution.
